### PR TITLE
Centralize Node.js version configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version-file: package.json
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "readability-wk",
 	"version": "0.0.0",
 	"private": true,
+	"engines": {
+		"node": "24"
+	},
 	"packageManager": "pnpm@11.10.0",
 	"scripts": {
 		"deploy": "wrangler deploy",


### PR DESCRIPTION
## Summary
- define Node.js 24 in `package.json` as the repository source of truth
- make `actions/setup-node` read the version from `package.json`
- keep pnpm resolution through the existing `packageManager` field

## Validation
- `CI=true mise x node@24 -- corepack pnpm install --frozen-lockfile`
- `mise x node@24 -- corepack pnpm run typecheck`
- `mise x node@24 -- corepack pnpm test --run`
- `mise x node@24 -- corepack pnpm run build`
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format plain .`
- `git diff --check`