### PR TITLE
Update pnpm to 11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"engines": {
 		"node": "24"
 	},
-	"packageManager": "pnpm@11.11.0",
+	"packageManager": "pnpm@11.13.0",
 	"scripts": {
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",


### PR DESCRIPTION
## Summary

- update the package manager source of truth from pnpm 11.11.0 to pnpm 11.13.0
- keep the workflow version-free so `pnpm/action-setup` continues to read `package.json`

## Root cause

The pnpm 11.12.0 update fails inside the `pnpm/action-setup` self-installer before dependency installation. The published package structure is corrected in pnpm 11.13.0.

## Validation

- `pnpm install --lockfile-only` (no lockfile diff)
- `pnpm install --frozen-lockfile`
- `pnpm run cf-typegen`
- `git diff --exit-code -- worker-configuration.d.ts`
- `pnpm run typecheck`
- `pnpm test --run`
- `pnpm run build`
- `pinact run --check`
- `zizmor --format plain .`
