### PR TITLE
Run workflow security checks in parallel

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -24,12 +24,13 @@ jobs:
         with:
           aqua_version: v2.61.0
 
-      - name: Check action pinning
-        run: pinact run --check
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - parallel:
+          - name: Check action pinning
+            run: pinact run --check
+            env:
+              GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Audit workflows
-        run: zizmor --format github .
-        env:
-          GH_TOKEN: ${{ github.token }}
+          - name: Audit workflows
+            run: zizmor --format github .
+            env:
+              GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- run `pinact run --check` and `zizmor --format github .` concurrently with GitHub Actions `parallel:` steps
- keep each check's token environment and logs separate
- exercise zizmor v1.27.0's experimental parallel-step support in the security workflow

## Why

The two checks are independent, read-only workflow inspections. Running them together avoids serializing the checks while preserving both results.

## Validation

- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format github .`
- `git diff --check`
